### PR TITLE
Fix type error 

### DIFF
--- a/key_value_store_web/lib/key_value_store_web.dart
+++ b/key_value_store_web/lib/key_value_store_web.dart
@@ -19,7 +19,7 @@ class WebKeyValueStore implements KeyValueStore {
   final Storage _storage;
 
   @override
-  Set<String> getKeys() => _storage.keys;
+  Set<String> getKeys() => _storage.keys.toSet();
 
   @override
   bool getBool(String key) => _storage[key] == 'true';

--- a/key_value_store_web/test/key_value_store_web_test.dart
+++ b/key_value_store_web/test/key_value_store_web_test.dart
@@ -24,6 +24,12 @@ void main() {
       expect(localStorage.getKeys(), ['key #1', 'key #2']);
     });
 
+    test('getKeys type', () {
+      when(mockStorage.keys).thenReturn(List());
+
+      expect(localStorage.getKeys().runtimeType, Set<String>().runtimeType);
+    });
+
     test('getBool', () {
       when(mockStorage['myTrueBool']).thenReturn(json.encode(true));
       when(mockStorage['myFalseBool']).thenReturn(json.encode(false));


### PR DESCRIPTION
The actual return value of `getKeys` function caused a type error in `List`.

> Expected a value of type 'Set<String>', but got one of type 'List<String>'

It corrected by setting what returned in `List` as `Set`.

https://github.com/dart-lang/sdk/blob/master/sdk/lib/html/dart2js/html_dart2js.dart